### PR TITLE
Adding configurable log levels

### DIFF
--- a/lib/booker.rb
+++ b/lib/booker.rb
@@ -19,8 +19,10 @@ module Booker
 
     def initialize(key, secret, options = {})
       @production = options.fetch(:production) { false }
+      @log_level = options.fetch(:log_level) { Logger::DEBUG }
       @key = key
       @secret = secret
+      set_log_level!
       set_access_token!
       set_server_time_offset!
     end
@@ -343,6 +345,10 @@ module Booker
 
       def get url
         HTTParty.get url
+      end
+
+      def set_log_level!
+        logger.level = @log_level
       end
 
       def set_access_token!


### PR DESCRIPTION
I needed to be able to silence the debug output for tests while leaving it in development and production.

This allows you to do pass a default log level like so:

```ruby
Booker::Client.new(key, secret, log_level: determine_log_level)

def determine_log_level
  Rails.env == "test" ? Logger::ERROR : Logger::DEBUG
end 
```